### PR TITLE
Set a comfortable when we know data is coming.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -327,6 +327,10 @@ impl Client {
     fn read_frame_headers_body(&mut self, command: String) -> Fallible<(String, Headers, Vec<u8>)> {
         let mut buf = String::new();
         let mut headers = BTreeMap::new();
+
+        // Given we are half way into a frame, we can be reasonably sure that
+        // more data is coming soon, so reset our timeouts.
+        try!(self.reset_timeouts(None));
         loop {
             buf.clear();
             try!(self.rdr.read_line(&mut buf));


### PR DESCRIPTION
This _should_ give us around about the keepalive interval to read the next frame.

Because we mostly use `self.read_line()`, but inside `read_frame_headers_body` directly use `self.rdr`, we need to ensure that in the latter case, we set our timeout to be a fairly conservative value. 

Because reading the command will have reset the last read time, we can effectively allow the server to client heartbeat interval to actually read the next frame. Although sadly, if that fails, it'll still result in an ugly stacktrace.