### PR TITLE
Broadly handle errors

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -244,6 +244,10 @@ async fn run_s2c(
                             trace!("Acked receipt: {:?}", receipt_id)
                         }
                     }
+                    Command::Error => {
+                        error!("Error frame received: {:?}", frame.headers);
+                        return Err(StompError::StompError(frame));
+                    }
                     _ => warn!("Unhandled frame type from server: {:?}", frame.command),
                 }
             }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -1,3 +1,5 @@
+use std::{collections::BTreeMap, fmt};
+
 use thiserror::Error;
 
 use crate::parser::ParseError;
@@ -7,8 +9,8 @@ pub type Result<T> = std::result::Result<T, StompError>;
 
 #[derive(Debug, Error)]
 pub enum StompError {
-    #[error("stomp error: {0:?}")]
-    StompError(Frame),
+    #[error("stomp error: {0}")]
+    StompError(ErrorFrame),
     #[error("Protocol error")]
     ProtocolError,
     #[error("Tried to ack a frame with no `ack` header")]
@@ -33,4 +35,33 @@ pub enum StompError {
     ConnectionDropped2(#[from] futures::channel::oneshot::Canceled),
     #[error("Timeout: {0}")]
     TimedOut(#[from] tokio::time::Elapsed),
+}
+
+pub struct ErrorFrame {
+    headers: BTreeMap<String, String>,
+}
+
+impl From<Frame> for ErrorFrame {
+    fn from(src: Frame) -> Self {
+        let Frame { headers, .. } = src;
+        ErrorFrame { headers }
+    }
+}
+
+impl fmt::Debug for ErrorFrame {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        fmt.debug_struct("ErrorFrame")
+            .field("headers", &self.headers)
+            .finish()
+    }
+}
+
+impl fmt::Display for ErrorFrame {
+    fn fmt(&self, fmt: &mut fmt::Formatter) -> fmt::Result {
+        if let Some(msg) = self.headers.get("message") {
+            write!(fmt, "From server: {}", msg)
+        } else {
+            write!(fmt, "(Unknown error)")
+        }
+    }
 }

--- a/src/errors.rs
+++ b/src/errors.rs
@@ -34,28 +34,3 @@ pub enum StompError {
     #[error("Timeout: {0}")]
     TimedOut(#[from] tokio::time::Elapsed),
 }
-
-#[cfg(never)]
-error_chain! (
-    foreign_links {
-        io::Error, Io;
-        num::ParseIntError, ParseInt;
-        time::SystemTimeError, SystemTime;
-    }
-
-    errors {
-        StompError(command: String, headers:BTreeMap<String, String>, body: String) {
-            description("stomp error")
-            display("stomp error: {}: {:?}: {:?}", command, headers, body)
-        }
-        ProtocolError {
-            description("protocol error")
-        }
-        NoAckHeader {
-            description("Tried to ack a frame with no `ack` header")
-        }
-        PeerFailed {
-            description("peer seems to be unresponsive")
-        }
-    }
-);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,6 @@ mod parser;
 mod protocol;
 mod unparser;
 
-pub use client::{connect, Client, Subscription};
+pub use client::{connect, connect_on, Client, Subscription};
 pub use errors::StompError;
 pub use protocol::{AckMode, Frame};

--- a/tests/zzz_end_to_end.rs
+++ b/tests/zzz_end_to_end.rs
@@ -9,6 +9,7 @@ use std::time::Duration;
 
 use futures::stream::StreamExt;
 use stomping::*;
+use tokio::time::timeout;
 use uuid::Uuid;
 
 #[tokio::test]
@@ -358,4 +359,43 @@ async fn should_allow_disconnect_by_dropping_with_pending_deliveries() {
     let res = conn_task.await;
     assert!(res.is_ok(), "Conection exited normally");
     info!("Disconnected first connection; reconnecting");
+}
+
+#[tokio::test]
+async fn should_fail_when_we_force_an_error() {
+    env_logger::try_init().unwrap_or_default();
+    let (conn, mut client) = connect(
+        ("localhost", 61613),
+        Some(("guest", "guest")),
+        None,
+        Default::default(),
+    )
+    .await
+    .expect("connect");
+    let conn_task = tokio::spawn(async {
+        debug!("Starting connection");
+        let res = conn.await;
+        debug!("Connection terminated: {:?}", res);
+        res
+    });
+
+    let queue = format!("/invalid-thing/can_round_trip_text-{}", Uuid::new_v4());
+
+    info!("Subscribing to queue");
+    // there's no reply to a subscribe frame to wait for, so we won't know
+    // it fails until we get the error frame.
+    let mut sub: Subscription = client
+        .subscribe(&queue, "one", AckMode::Auto, Default::default())
+        .await
+        .expect("subscribe succeeds ok");
+
+    let res = timeout(Duration::from_millis(1000), conn_task)
+        .await
+        .expect("no timeout")
+        .expect("joins okay");
+
+    match res.expect_err("has error") {
+        StompError::StompError { .. } => {}
+        e => panic!("Unexpected error: Got: {:?}", e),
+    }
 }

--- a/tests/zzz_end_to_end.rs
+++ b/tests/zzz_end_to_end.rs
@@ -384,7 +384,7 @@ async fn should_fail_when_we_force_an_error() {
     info!("Subscribing to queue");
     // there's no reply to a subscribe frame to wait for, so we won't know
     // it fails until we get the error frame.
-    let mut sub: Subscription = client
+    let mut _sub: Subscription = client
         .subscribe(&queue, "one", AckMode::Auto, Default::default())
         .await
         .expect("subscribe succeeds ok");


### PR DESCRIPTION
The crudest method of error handling possible here is to just terminate the connection on an error. So let's just do that.